### PR TITLE
`parseModel()` performance improvements

### DIFF
--- a/contributions.go
+++ b/contributions.go
@@ -280,7 +280,7 @@ func treeShap(
 	isMissing := features[splitIndex] == nil // nil means missing.
 	hotIndex := getNextNode(
 		hasMissing,
-		node,
+		&node,
 		nodeIndex,
 		features[splitIndex],
 		isMissing,

--- a/parse.go
+++ b/parse.go
@@ -56,7 +56,7 @@ type TreeParam struct {
 // Tree is one tree in an XGBoost model. It's the representation we process
 // XGBTree into.
 type Tree struct {
-	Nodes    []*Node // Index 0 is the root.
+	Nodes    []Node // Index 0 is the root.
 	NumNodes int
 }
 
@@ -136,11 +136,7 @@ func parseTree(
 		return nil, fmt.Errorf("getting num nodes as int64: %w", err)
 	}
 
-	var nodes []*Node
-	for i := 0; i < int(numNodes); i++ {
-		nodes = append(nodes, &Node{})
-	}
-
+	nodes := make([]Node, numNodes)
 	for i := 0; i < int(numNodes); i++ {
 		nodes[i].Data = NodeData{
 			BaseWeight:     xt.BaseWeights[i],
@@ -158,8 +154,8 @@ func parseTree(
 			continue
 		}
 
-		nodes[i].Left = nodes[left]
-		nodes[i].Right = nodes[right]
+		nodes[i].Left = &nodes[left]
+		nodes[i].Right = &nodes[right]
 	}
 
 	return &Tree{

--- a/parse.go
+++ b/parse.go
@@ -62,19 +62,19 @@ type Tree struct {
 
 // Node is a node in the Tree.
 type Node struct {
-	Data  NodeData
 	Left  *Node
 	Right *Node
+	Data  NodeData
 }
 
 // NodeData is a Node's data.
 type NodeData struct {
+	ID             int
+	SplitIndex     int
+	SplitCondition float32
+	SumHessian     float32
 	BaseWeight     float32
 	DefaultLeft    bool
-	ID             int
-	SplitCondition float32
-	SplitIndex     int
-	SumHessian     float32
 }
 
 // IsLeaf returns whether the Node is a leaf.

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,14 @@
+package xgbshap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkParseModel(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _, err := parseModel("testdata/small-model/model.json")
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
Quick perf wins in `parseModel()`: 29.79% less allocs, 6.28% less memory used, 1.41% speed up in runtime.

```sh
$ benchstat old.txt new.txt                        
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgbshap
              │   old.txt   │              new.txt               │
              │   sec/op    │   sec/op     vs base               │
ParseModel-10   684.4µ ± 1%   674.7µ ± 2%  -1.41% (p=0.011 n=10)

              │   old.txt    │               new.txt               │
              │     B/op     │     B/op      vs base               │
ParseModel-10   186.6Ki ± 0%   174.9Ki ± 0%  -6.28% (p=0.000 n=10)

              │   old.txt   │               new.txt               │
              │  allocs/op  │  allocs/op   vs base                │
ParseModel-10   1.588k ± 0%   1.115k ± 0%  -29.79% (p=0.000 n=10)
```

<details>
<summary>before</summary>

```sh
$ go test -run=^$ -bench=. -benchmem -count=10 | tee old.txt
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgbshap
BenchmarkParseModel-10    	    1752	    683160 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1737	    683685 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1744	    685918 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1744	    684606 ns/op	  191081 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1748	    683018 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1747	    684094 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1746	    688603 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1759	    799020 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1736	    682506 ns/op	  191080 B/op	    1588 allocs/op
BenchmarkParseModel-10    	    1748	    686241 ns/op	  191080 B/op	    1588 allocs/op
PASS
ok  	github.com/maxmind/xgbshap	15.022s
```

</details>

<details>
<summary>after</summary>

```sh
$ go test -run=^$ -bench=. -benchmem -count=10 | tee new.txt
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgbshap
BenchmarkParseModel-10    	    1776	    676684 ns/op	  179090 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1773	    672871 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1774	    674630 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1774	    675294 ns/op	  179089 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1767	    674292 ns/op	  179089 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1767	    672589 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1772	    674810 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1770	    777569 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1776	    672042 ns/op	  179088 B/op	    1115 allocs/op
BenchmarkParseModel-10    	    1770	    687123 ns/op	  179088 B/op	    1115 allocs/op
PASS
ok  	github.com/maxmind/xgbshap	13.984s
```

</details>